### PR TITLE
Improves logging

### DIFF
--- a/git_credential_manager.go
+++ b/git_credential_manager.go
@@ -31,12 +31,17 @@ func NewGitCredentialManager(bindingResolver BindingResolver, executable Executa
 }
 
 func (g GitCredentialManager) Setup(workingDir, platformDir string) error {
-	g.logs.Process("Configuring credentials")
-
 	bindings, err := g.bindingResolver.Resolve("git-credentials", "", platformDir)
 	if err != nil {
 		return err
 	}
+
+	if len(bindings) == 0 {
+		// If there are no bindings then we are done
+		return nil
+	}
+
+	g.logs.Process("Configuring credentials")
 
 	uniqueContext := map[string]interface{}{}
 
@@ -80,6 +85,7 @@ func (g GitCredentialManager) Setup(workingDir, platformDir string) error {
 
 	}
 
+	g.logs.Process("Added %d custom git credential manager(s) to the git config", len(uniqueContext))
 	g.logs.Break()
 	return nil
 }

--- a/git_credential_manager_test.go
+++ b/git_credential_manager_test.go
@@ -64,6 +64,8 @@ func testGitCredentialManager(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(bindingResolver.ResolveCall.Receives.PlatformDir).To(Equal(platformDir))
 				Expect(executable.ExecuteCall.CallCount).To(Equal(0))
+
+				Expect(buffer.String()).ToNot(ContainSubstring("Configuring credentials"))
 			})
 		})
 
@@ -91,6 +93,9 @@ func testGitCredentialManager(t *testing.T, context spec.G, it spec.S) {
 						"credential.helper",
 						fmt.Sprintf("!f() { cat %q; }; f", filepath.Join("some-path", "credentials")),
 					}))
+
+					Expect(buffer.String()).To(ContainSubstring("Configuring credentials"))
+					Expect(buffer.String()).To(ContainSubstring("Added 1 custom git credential manager(s) to the git config"))
 				})
 			})
 
@@ -164,6 +169,9 @@ func testGitCredentialManager(t *testing.T, context spec.G, it spec.S) {
 					"credential.https://example.com.helper",
 					fmt.Sprintf("!f() { cat %q; }; f", filepath.Join("other-path", "credentials")),
 				}))
+
+				Expect(buffer.String()).To(ContainSubstring("Configuring credentials"))
+				Expect(buffer.String()).To(ContainSubstring("Added 2 custom git credential manager(s) to the git config"))
 			})
 		})
 

--- a/integration/credential_configuration_test.go
+++ b/integration/credential_configuration_test.go
@@ -83,6 +83,7 @@ func testCredentialConfiguration(t *testing.T, context spec.G, it spec.S) {
 				`    REVISION -> "2df6ac40991b695cc6c31faa79926980ff7dc0ff"`,
 				"",
 				"  Configuring credentials",
+				"  Added 1 custom git credential manager(s) to the git config",
 				"",
 				"Paketo Credential Fill Buildpack",
 				"protocol=https",


### PR DESCRIPTION
- Credential configuring message now only prints if there are any
bindings instead of always
- Now print the number of custom credential managers that were
configured